### PR TITLE
Adiciona google analytics id de acompanhamento

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -34,7 +34,14 @@ module.exports = {
   /*
   ** Nuxt.js modules
   */
-  modules: [],
+  modules: [
+    [
+      '@nuxtjs/google-analytics',
+      {
+        id: 'UA-120241684-2'
+      }
+    ]
+  ],
 
   /*
   ** Build configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -1071,6 +1071,14 @@
       "integrity": "sha512-Scz5oYNtVwePF1ebXcWPrFxBpNF5wAkYh8L++6f2ZdLyUb1mCOwzE2+oVZxS25hGCYUyecFEshbqeSwkC+ktqA==",
       "dev": true
     },
+    "@nuxtjs/google-analytics": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/google-analytics/-/google-analytics-2.1.0.tgz",
+      "integrity": "sha512-JVHcCV2nNuY2bnk3C1C5cGIEWc3YA0pECt5BvbPwa8+ZeY1lxbMskm9xAoKI4V/WyWUDmA2kYtkbERSrifi0mw==",
+      "requires": {
+        "vue-analytics": "^5.16.2"
+      }
+    },
     "@nuxtjs/youch": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@nuxtjs/youch/-/youch-4.2.3.tgz",
@@ -9014,6 +9022,11 @@
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.8.tgz",
       "integrity": "sha512-+vp9lEC2Kt3yom673pzg1J7T1NVGuGzO9j8Wxno+rQN2WYVBX2pyo/RGQ3fXCLh2Pk76Skw/laAPCuBuEQ4diw=="
+    },
+    "vue-analytics": {
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/vue-analytics/-/vue-analytics-5.16.2.tgz",
+      "integrity": "sha512-5JKGnVF33VHlXFREzht9z3Z11N4IA8vXNnpvYeAf72rEUyAuuU9Q9kX34bULW2CxMrahr8m06IB8+91GX0Ruag=="
     },
     "vue-eslint-parser": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "precommit": "npm run lint"
   },
   "dependencies": {
+    "@nuxtjs/google-analytics": "^2.1.0",
     "cross-env": "^5.2.0",
     "nuxt": "^2.4.0"
   },


### PR DESCRIPTION
Adiciona plugin do Google Analytics e nosso id de acompanhamento, para visualizarmos os acessos da página