### PR TITLE
Todos os projetos com a mesma altura

### DIFF
--- a/components/home/sessoes/projetos/ProjetoCard.vue
+++ b/components/home/sessoes/projetos/ProjetoCard.vue
@@ -70,6 +70,7 @@ export default {
   .card {
     width: 95%;
     margin: 10px 10px;
+    height: 50vh;
   }
   img {
     width: 80%;

--- a/components/home/sessoes/projetos/Projetos.vue
+++ b/components/home/sessoes/projetos/Projetos.vue
@@ -84,9 +84,6 @@ export default {
   display: flex;
   widows: 100%;
   flex-direction: row;
-}
-
-li {
   margin: 10px 10px 0 10px;
 }
 

--- a/components/home/sessoes/projetos/Projetos.vue
+++ b/components/home/sessoes/projetos/Projetos.vue
@@ -7,8 +7,10 @@
       </span>
     </div>
     <div class="projetos">
-      <ul v-for="projeto in projetos" :key="projeto.site">
-        <li><projeto-card :projeto="projeto" /></li>
+      <ul class="list">
+        <li v-for="projeto in projetos" :key="projeto.site" class="list-item">
+          <projeto-card :projeto="projeto" />
+        </li>
       </ul>
     </div>
   </section>
@@ -71,8 +73,17 @@ export default {
   margin: 0 10vh;
 }
 
-ul {
+.list {
   list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.list-item {
+  display: flex;
+  widows: 100%;
+  flex-direction: row;
 }
 
 li {


### PR DESCRIPTION
Eu tava dando uma olhada nas últimas versões, e percebi que os projetos estavam dessa forma, um maiores que os outros:
![Screenshot from 2019-03-09 16-50-50](https://user-images.githubusercontent.com/19390820/54076723-27f99200-428d-11e9-93ff-a35095286a86.png)

Então, utilizando algumas propriedades do `flex-box` e alterando o `v-for`, consegui obter o seguinte resultado (responsivo):
![Screenshot from 2019-03-09 16-50-28](https://user-images.githubusercontent.com/19390820/54076738-5b3c2100-428d-11e9-9c4a-814871c3f2e4.png)

E aí, o que acham?