### PR TITLE
Modifica o link do Github de LukeHxH para lucasmedeiros

### DIFF
--- a/components/home/sessoes/equipe/Equipe.vue
+++ b/components/home/sessoes/equipe/Equipe.vue
@@ -60,7 +60,7 @@ export default {
         },
         {
           nome: 'Lucas Medeiros',
-          url_github: 'https://github.com/LukeHxH',
+          url_github: 'https://github.com/lucasmedeiros',
           imagem: 'lucas.jpeg'
         },
         {


### PR DESCRIPTION
Esta PR altera o link do meu Github na sessão dos integrantes da equipe, de `LukeHxH` para `lucasmedeiros`, já que eu alterei meu username e agora ele é `lucasamedeiros`.